### PR TITLE
Update julia.jl

### DIFF
--- a/Sovereign_Default/julia.jl
+++ b/Sovereign_Default/julia.jl
@@ -1,9 +1,8 @@
-using DelimitedFiles, Statistics
+using DelimitedFiles, Statistics, Strided
 
 # Load grid for log(y) and transition matrix
 const logy_grid = readdlm("logy_grid.txt")[:]
 const Py = readdlm("P.txt")
-
 
 function main(nB=351, repeats=500)
     β = .953
@@ -12,7 +11,7 @@ function main(nB=351, repeats=500)
     θ = 0.282
     ny = size(logy_grid, 1)
 
-    Bgrid = LinRange(-.45, .45, nB)
+    Bgrid = collect(range(-.45, .45, length=nB))
     ygrid = exp.(logy_grid)
 
     ymean = mean(ygrid) .+ 0 * ygrid
@@ -29,46 +28,35 @@ function main(nB=351, repeats=500)
 
     zero_ind = Int(ceil(nB / 2))
 
-    u(c, γ) = c^(1 - γ) / (1 - γ)
+    @fastmath u(c, γ) = c^(1.0 - γ) / (1.0 - γ)
+    relu(x) = x < 1e-14 ? 1e-14 : x
 
-    t0 = time()
     function iterate(V, Vc, Vd, Q)
-        EV = Py * V
-        EVd = Py * Vd
-        EVc = Py * Vc
+        @fastmath begin 
+            EV = Py * V
+            EVd = Py * Vd
+            EVc = Py * Vc
 
-        Vd_target = u.(def_y, γ) + β * (θ * EVc[:, zero_ind] + (1 - θ) * EVd[:])
-        Vd_target = reshape(Vd_target, (ny, 1))
+            Vd_target = @strided u.(def_y, γ) + β * (θ * EVc[:, zero_ind] + (1.0 - θ) * EVd)
+            Vd_target = reshape(Vd_target, (ny, 1))
 
-        Qnext = reshape(Q, (ny, 1, nB))
+            Qnext = reshape(Q, (ny, 1, nB))
+            c =  @strided relu.(y .- Qnext .* Bnext .+ B)
+            #map!(x->max(x, 1e-14), c, c)
+            EV = reshape(EV, (ny, 1, nB))
+            m = @strided u.(c, γ) .+ β .* EV
+            
+            Vc_target = reshape(maximum(m, dims=3), (ny, nB))
 
-        m = Array{Float64,3}(undef, ny, nB, nB)
-        @inbounds for k = 1:nB
-            Bk = Bgrid[k]
-            for j = 1:nB
-                Bj = Bgrid[j]
-                @simd for i = 1:ny
-                    c = ygrid[i] - Q[i,k] * Bk + Bj
-                    c = max(c, 1e-14)
-                    m[i, j, k] = u(c, γ) + β * EV[i,j]
-                end
-            end
+            Vd_compat = Vd * ones(1, nB)
+            default_states = float(Vd_compat .> Vc)
+            default_prob = Py * default_states
+            Q_target = @strided (1. .- default_prob) ./ (1 + r)
+
+            V_target = @strided max.(Vc, Vd_compat)
+
+            return V_target, Vc_target, Vd_target, Q_target
         end
-        # c = @. y - Qnext * Bnext + B
-        # map!(x->max(x, 1e-14), c, c)
-        # EV = reshape(EV, (ny, 1, nB))
-        # m =  @. u(c, γ) + β * EV
-        Vc_target = reshape(maximum(m, dims=3), (ny, nB))
-
-        Vd_compat = Vd * ones(1, nB)
-        default_states = float(Vd_compat .> Vc)
-        default_prob = Py * default_states
-        Q_target = (1. .- default_prob) ./ (1 + r)
-
-        V_target = max.(Vc, Vd_compat)
-
-        return V_target, Vc_target, Vd_target, Q_target
-
     end
 
     iterate(V, Vc, Vd, Q)  # warmup
@@ -77,8 +65,10 @@ function main(nB=351, repeats=500)
         V, Vc, Vd, Q = iterate(V, Vc, Vd, Q)
     end
     t1 = time()
+    
     out = (t1 - t0) / repeats
-
 end
 
-print(1000 * main(1351, 10))
+for sz in [151, 351, 551, 751, 951, 1151, 1351, 1551]
+    println(sz, ":  ", 1000 * main(sz, 10))
+end

--- a/Sovereign_Default/julia.jl
+++ b/Sovereign_Default/julia.jl
@@ -1,5 +1,5 @@
 using Pkg
-"Strided" in keys(Pkg.installed()) ? pkg"add Strided" : nothing
+"Strided" in keys(Pkg.installed()) ? Pkg.add("Strided") : nothing
 
 using DelimitedFiles, Statistics, Strided
 

--- a/Sovereign_Default/julia.jl
+++ b/Sovereign_Default/julia.jl
@@ -1,5 +1,5 @@
 using Pkg
-"Strided" in keys(Pkg.installed()) ? Pkg.add("Strided") : nothing
+"Strided" in keys(Pkg.installed()) ? nothing : Pkg.add("Strided")
 
 using DelimitedFiles, Statistics, Strided
 

--- a/Sovereign_Default/julia.jl
+++ b/Sovereign_Default/julia.jl
@@ -1,3 +1,6 @@
+using Pkg
+"Strided" in keys(Pkg.installed()) ? pkg"add Strided" : nothing
+
 using DelimitedFiles, Statistics, Strided
 
 # Load grid for log(y) and transition matrix


### PR DESCRIPTION
I find significant speed improvements using the above changes for all sizes other than `151` (the smallest) while producing answers that agree with the author's original code. 

Here are the timings I get for all the sizes listed in the paper:
```julia
151:   326.1284828186035
351:   308.24360847473145
551:   690.5834913253784
751:   1231.9454908370972
951:   1912.0723962783813
1151:  5935.046696662903
1351:  18267.05288887024
1551:  29274.00109767914
```
and I'm using a nearly identical machine to the one the authors used for benchmarking. 

The second time it's run, the timings improve. I'm not sure why exactly that is, it seems like all the JIT overhead should have been hit before the benchmarking loop in the first function call, but nonetheless here is the second run timing:
```julia
julia> include("julia.jl")
151:  89.70789909362793
351:  288.47689628601074
551:  686.4475965499878
751:  1315.5532121658325
951:  2086.0692977905273
1151:  5694.838190078735
1351:  18829.65850830078
1551:  31184.902906417847
```